### PR TITLE
Change timestamp data types to datetime

### DIFF
--- a/scaffolds/CrmHubSpot/operations/CreateConfiguration/keboolaWrDbSnowflakeSnowflake.json
+++ b/scaffolds/CrmHubSpot/operations/CreateConfiguration/keboolaWrDbSnowflakeSnowflake.json
@@ -5,8 +5,7 @@
         "name": "Snowflake",
         "configuration": {
             "parameters": {
-                "db": {
-                },
+                "db": {},
                 "tables": [
                     {
                         "dbName": "ACTIVITY",
@@ -56,7 +55,7 @@
                             {
                                 "name": "activity_date",
                                 "dbName": "ACTIVITY_DATE",
-                                "type": "timestamp",
+                                "type": "datetime",
                                 "size": "",
                                 "nullable": true,
                                 "default": ""

--- a/scaffolds/CrmPipedrive/operations/CreateConfiguration/keboolaWrDbSnowflakeSnowflake.json
+++ b/scaffolds/CrmPipedrive/operations/CreateConfiguration/keboolaWrDbSnowflakeSnowflake.json
@@ -5,8 +5,7 @@
         "name": "Snowflake",
         "configuration": {
             "parameters": {
-                "db": {
-                },
+                "db": {},
                 "tables": [
                     {
                         "dbName": "ACTIVITY",
@@ -56,7 +55,7 @@
                             {
                                 "name": "activity_date",
                                 "dbName": "ACTIVITY_DATE",
-                                "type": "timestamp",
+                                "type": "datetime",
                                 "size": "",
                                 "nullable": true,
                                 "default": ""

--- a/scaffolds/CrmSalesforce/operations/CreateConfiguration/keboolaWrDbSnowflakeSnowflake.json
+++ b/scaffolds/CrmSalesforce/operations/CreateConfiguration/keboolaWrDbSnowflakeSnowflake.json
@@ -5,8 +5,7 @@
         "name": "Snowflake",
         "configuration": {
             "parameters": {
-                "db": {
-                },
+                "db": {},
                 "tables": [
                     {
                         "dbName": "ACTIVITY",
@@ -56,7 +55,7 @@
                             {
                                 "name": "activity_date",
                                 "dbName": "ACTIVITY_DATE",
-                                "type": "timestamp",
+                                "type": "datetime",
                                 "size": "",
                                 "nullable": true,
                                 "default": ""

--- a/scaffolds/CrmSnowflakeWriterExternal/operations/CreateConfiguration/keboolaWrDbSnowflakeCRM.json
+++ b/scaffolds/CrmSnowflakeWriterExternal/operations/CreateConfiguration/keboolaWrDbSnowflakeCRM.json
@@ -55,7 +55,7 @@
                             {
                                 "name": "activity_date",
                                 "dbName": "ACTIVITY_DATE",
-                                "type": "timestamp",
+                                "type": "datetime",
                                 "size": "",
                                 "nullable": true,
                                 "default": ""


### PR DESCRIPTION
Change timestamp data types to datetime, so the time is not converted to different time zone during upload to Snowflake DB.