### PR TITLE
Adding drop down selection for Geneea App domain field

### DIFF
--- a/scaffolds/ReviewTrackersHospitality/manifest.json
+++ b/scaffolds/ReviewTrackersHospitality/manifest.json
@@ -43,7 +43,33 @@
             "componentId": "geneea.nlp-analysis-v2",
             "name": "Reviews analysis",
             "required": true,
-            "schema": null
+            "schema": {
+                "type": "object",
+                "required": [
+                    "domain"
+                ],
+                "properties": {
+                    "domain": {
+                        "title": "Domain",
+                        "type": "string",
+                        "enum": [
+                            "news",
+                            "voc-hospitality",
+                            "voc-banking",
+                            "tcc"
+                        ],
+                        "options": {
+                            "enum_titles": [
+                                "News Articles",
+                                "Voice of the Customer - Hospitality",
+                                "Voice of the Customer - Banking",
+                                "Voice of the Customer - Transportation"
+                            ]
+                        },
+                        "description": "Select preferred Geneea domain to better analyze your text data."
+                    }
+                }
+            }
         },
         {
             "id": "transformation02Reviews(postNLP)",

--- a/scaffolds/ReviewTrackersHospitality/operations/CreateConfiguration/geneeaNlpAnalysisV2ReviewsAnalysis.json
+++ b/scaffolds/ReviewTrackersHospitality/operations/CreateConfiguration/geneeaNlpAnalysisV2ReviewsAnalysis.json
@@ -41,7 +41,6 @@
                     "sentiment",
                     "relations"
                 ],
-                "domain": "voc-hospitality",
                 "use_beta": false,
                 "correction": "basic",
                 "diacritization": "none",


### PR DESCRIPTION
ReviewTrackers scaffold jsem upravil tak, aby ve wizardu byla možnost výběru Geneea **domain** z dostupných hodnot. Ty jsou doplněny do _manifestu_. V configu appky pak **domain** odebírám, protože tam bude doplěna wizardem.

Testoval jsem nasazení přes tenhle config.json:
```
{
    "action": "useScaffold",
    "parameters": {
        "id": "ReviewTrackersHospitality",
        "inputs": [
            {
                "id": "kdsTeamExReviewtrackersSurveys",
                "values": {
                    "parameters": {
                        "username": "",
                        "#password": ""
                    }
                }
            },
            {
                "id": "transformation01Reviews(preNLP)",
                "values": null
            },
            {
                "id": "geneeaNlpAnalysisV2ReviewsAnalysis",
                "values": {
                    "parameters": {
                        "domain": "voc-banking"
                    }
                }
            },
            {
                "id": "transformation02Reviews(postNLP)",
                "values": null
            },
            {
                "id": "keboolaWrDbSnowflakeLooker",
                "values": null
            },
            {
                "id": "orchestrationReviews",
                "values": null
            }
        ]
    }
}
```

Výsledek vypadá dobře: https://connection.keboola.com/admin/projects/6995/applications/geneea.nlp-analysis-v2/565172213
Netuším ale, jestli si s tím poradí ten wizard, páč to nemám jak otestovat.