### PR TITLE
disable doubled outputs check

### DIFF
--- a/src/SyncActions/UseScaffoldExecutionContext/RequirementsValidator.php
+++ b/src/SyncActions/UseScaffoldExecutionContext/RequirementsValidator.php
@@ -20,12 +20,18 @@ final class RequirementsValidator
             );
         }
 
+        /*
+         * With the introduction of new transformation and Azure stacks, we have to create new scaffolds.
+         * There are now the same Scaffolds for Azure and AWS stacks because they have incompatible transformations.
+         * This means that we have to allow (hopefully temporarily) scaffolds with same outputs and disable
+         * the following check:
         if (count($executionContext->getManifestOutputs()) !== 0) {
             self::validateOutputs(
                 $usedScaffoldManifestsOutputs,
                 $executionContext
             );
         }
+        */
     }
 
     public static function validateRequirements(

--- a/tests/functional/ComponentTest.php
+++ b/tests/functional/ComponentTest.php
@@ -424,7 +424,7 @@ class ComponentTest extends AbstractDatadirTestCase
 
         $specification = new DatadirTestSpecification(
             __DIR__,
-            1,
+            0,
             null,
             null,
             null

--- a/tests/functional/ComponentTest.php
+++ b/tests/functional/ComponentTest.php
@@ -298,6 +298,7 @@ class ComponentTest extends AbstractDatadirTestCase
 
     public function testCantCreateScaffoldWithTheSameOutputs(): void
     {
+        $this->markTestSkipped('We have to enable scaffolds with same outputs for different stacks (AWS/Azure).');
         $this->cleanUpWorkspace();
 
         $specification = new DatadirTestSpecification(


### PR DESCRIPTION
Tohle kontrolovalo jestli nejsou scaffoldy se stejnyma vystupama, protoze kdyz mas dve tabulky se stejnym tagem, tak nefunguje input mapping a cely se to rozjebe. Tzn. az se tohle mergne, tak si musis hlidat, ze ty vystupy scaffoldu jsou stejne jen mezi starym a novym scaffoldem a ne mezi dvouma novyma scaffoldama
