### PR TITLE
Remove "account" field from Sklik required

### DIFF
--- a/scaffolds/ShoptetEcommerce/manifest.json
+++ b/scaffolds/ShoptetEcommerce/manifest.json
@@ -43,8 +43,7 @@
                 "type": "object",
                 "title": "Sklik Extractor Configuration",
                 "required": [
-                    "#token",
-                    "accounts"
+                    "#token"
                 ],
                 "properties": {
                     "#token": {


### PR DESCRIPTION
Odstraňuju "account" z required array Sklik json schema, aby nebylo nutné jej vyplňovat ve wizardu.