### PR TITLE
Removing authorization part from the FB Ads config

### DIFF
--- a/scaffolds/ShoptetEcommerce/operations/CreateConfiguration/keboolaExFacebookAdsFacebookAds.json
+++ b/scaffolds/ShoptetEcommerce/operations/CreateConfiguration/keboolaExFacebookAdsFacebookAds.json
@@ -3,12 +3,6 @@
     "payload": {
         "name": "Facebook Ads",
         "configuration": {
-            "authorization": {
-                "oauth_api": {
-                    "id": "2079381",
-                    "version": 3
-                }
-            },
             "parameters": {
                 "accounts": {},
                 "api-version": "v10.0",


### PR DESCRIPTION
Tahle část způsobovala problémy, protože se má vytvářet až při autorizaci a my jsme tam cpali hodnotu dopředu.
Otestoval jsem nasazení scaffoldu bez ní, následně autorizoval (objevila se zároveň v configu) a proběhlo vše v pořádku: https://connection.north-europe.azure.keboola.com/admin/projects/46/jobs/4146264